### PR TITLE
ECSだとprint()がログとして表示されない #4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.11.2-slim-bullseye
+ENV PYTHONUNBUFFERED 1
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
PYTHONUNBUFFERED 1を追加することで、バッファーを無効にした。